### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Special thanks and credits goes to:
 -   [Finko42](https://github.com/Finko42) - for [Encryption and Hashing algorithms](https://github.com/Finko42/GreyHack)
 -   Ariavne - for allowing me to use their nickname as a command name(see `ariadne`)
 -   [rocketorbit](https://github.com/rocketorbit) - for [Simple Text Editor](https://github.com/rocketorbit/Simple-Text-Editor-for-Grey-Hack)
--   Guest - for Ukraininan translation
+-   Guest - for Ukrainian translation
 -   Simonize - for color theme
 
 If I've somehow forgotten to mention you in here then accept my apologizes! Open an issue and I'll add you as fast as I can!


### PR DESCRIPTION
The correct spelling for `Ukrainian` is `Ukrainian`